### PR TITLE
Force robot to face initial direction BEFORE charging.

### DIFF
--- a/action.lua
+++ b/action.lua
@@ -34,6 +34,7 @@ end
 
 local function charge()
     gps.go(config.chargerPos)
+    gps.turnTo(1)
     repeat
         os.sleep(0.5)
     until fullyCharged()


### PR DESCRIPTION
This allows the on/off redstone to stop the robot in its initial direction, which means if you wish, before a program is finished, you can turn it off, and start it up again and start a new program !!without!! having to break it and place it again.